### PR TITLE
Changes directory assignment and error log writing...

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,7 @@ import os
 import sys
 import traceback
 
-directory = os.path.split(os.path.abspath(sys.argv[0]))[0]
+directory = os.path.dirname(__file__)
 
 try:
 
@@ -47,7 +47,10 @@ def main():
                 pass
 
         text_error = traceback.format_exc()
-        traceback.print_exc(file=open(os.path.join(directory, 'error.log'), 'w'))
+
+        with open(os.path.join(directory, 'error.log'), 'w') as fd:
+            traceback.print_exc(file=fd)
+
         create_error_monitor()
 
 


### PR DESCRIPTION
While `os.path.split(os.path.abspath(sys.argv[0]))[0]` seems to work 
okay on Python, I've seen environment variables in other shells (such as 
Bash) cause issues, also `os.path.dirname(__file__)` _should_ be 
slightly faster.


To have the error log file close after writing it is generally a good 
idea to utilize a `with` block...


```Python
        with open(os.path.join(directory, 'error.log'), 'w') as fd:
            traceback.print_exc(file=fd)
```


... because leaving open file descriptors can cause issues that are hard 
to track-down.